### PR TITLE
Misc fixes for v0.44

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This installs `GhostMD.app` to `/Applications/` and creates a `ghostmd` CLI comm
 Requires Rust 1.75+ and Xcode with Metal on macOS.
 
 ```
-git clone https://github.com/user/ghostmd.git
+git clone https://github.com/mimoo/ghostmd.git
 cd ghostmd
 cargo build --release
 ./scripts/bundle-macos.sh
@@ -36,7 +36,7 @@ cp -r target/GhostMD.app /Applications/
 
 ### From release
 
-Download the latest `.tar.gz` from [Releases](https://github.com/user/ghostmd/releases), extract, and drag `GhostMD.app` to `/Applications/`.
+Download the latest `.tar.gz` from [Releases](https://github.com/mimoo/ghostmd/releases), extract, and drag `GhostMD.app` to `/Applications/`.
 
 ## Features
 


### PR DESCRIPTION
This PR fixes two small oversights:
1. ~chooses the right timer to determine a "random" adjective for default tab title. Before the resolution was nanoseconds, which on MacOS Tahoe always seems to be a multiple of 100, so computing modulo the length of the adjective length was always the same. Switching to us gives 6 "random-looking" digits, which serve the purpose.~ Fixed on `main` by now.
2. corrects the link to releases on the main README