### PR TITLE
fix: rename tab listens to Enter key now

### DIFF
--- a/crates/ghostmd/src/app_view/mod.rs
+++ b/crates/ghostmd/src/app_view/mod.rs
@@ -785,6 +785,11 @@ impl Render for GhostAppView {
             .on_action(cx.listener(|this: &mut Self, _action: &keybindings::PaletteConfirm, window, cx| {
                 match &this.active_overlay {
                     Some(OverlayKind::LocationPicker) => this.confirm_location_picker(window, cx),
+                    Some(OverlayKind::Palette) if this.rename_mode.is_some() => {
+                        // In rename mode, forward Enter to the input so the
+                        // InputEvent::PressEnter subscriber applies the rename.
+                        window.dispatch_action(Box::new(gpui_component::input::Enter { secondary: false }), cx);
+                    }
                     Some(OverlayKind::Palette) => this.palette_confirm(window, cx),
                     _ => {
                         window.dispatch_action(Box::new(gpui_component::input::Enter { secondary: false }), cx);


### PR DESCRIPTION
This fixed tab rename, which would ignore Enter before and only work on Cmd+Enter.
Claude did this, and it seems to work locally, but I haven't carefully checked for potential side effects. But since the whole thing is vibe coded so far, I guess it's fine.